### PR TITLE
fix: use statement_timeout instead of python decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "simplejson>=3.20.1",
     "sql-metadata>=2.17.0",
     "sqlglot>=26.16.4",
-    "timeout-decorator>=0.5.0",
     "vanna[anthropic,openai,pgvector,postgres]>=0.7.9",
 ]
 

--- a/suite/main.py
+++ b/suite/main.py
@@ -310,6 +310,9 @@ def eval(
                 with psycopg.connect(
                     get_psycopg_str(f"{dataset}_{inp['database']}")
                 ) as db:
+                    with db.cursor() as cur:
+                        cur.execute("SET LOCAL statement_timeout = 120000;")
+
                     error_path = eval_path / "error.txt"
                     if error_path.exists():
                         error_path.unlink()

--- a/suite/tasks/text_to_sql.py
+++ b/suite/tasks/text_to_sql.py
@@ -4,7 +4,6 @@ import time
 import polars as pl
 import psycopg
 import simplejson as json
-import timeout_decorator
 from polars.testing import assert_frame_equal
 from sql_metadata import Parser
 
@@ -87,23 +86,15 @@ async def run(
     with open(f"{path}/actual_query.sql", "w") as fp:
         fp.write(query)
 
-    @timeout_decorator.timeout(120)
-    def exe_gold():
-        try:
-            return pl.read_database(gold_query, conn)
-        except psycopg.DatabaseError as e:
-            raise GetExpectedError(e) from e
+    try:
+        expected = pl.read_database(gold_query, conn)
+    except psycopg.DatabaseError as e:
+        raise GetExpectedError(e) from e
 
-    expected = exe_gold()
-
-    @timeout_decorator.timeout(120)
-    def exe_actual():
-        try:
-            return pl.read_database(query, conn)
-        except psycopg.DatabaseError as e:
-            raise QueryExecutionError(e) from e
-
-    actual = exe_actual()
+    try:
+        actual = pl.read_database(query, conn)
+    except psycopg.DatabaseError as e:
+        raise QueryExecutionError(e) from e
 
     details = {
         "generated_query": query,

--- a/uv.lock
+++ b/uv.lock
@@ -4167,7 +4167,6 @@ dependencies = [
     { name = "simplejson" },
     { name = "sql-metadata" },
     { name = "sqlglot" },
-    { name = "timeout-decorator" },
     { name = "vanna", extra = ["anthropic", "openai", "pgvector", "postgres"] },
 ]
 
@@ -4194,7 +4193,6 @@ requires-dist = [
     { name = "simplejson", specifier = ">=3.20.1" },
     { name = "sql-metadata", specifier = ">=2.17.0" },
     { name = "sqlglot", specifier = ">=26.16.4" },
-    { name = "timeout-decorator", specifier = ">=0.5.0" },
     { name = "vanna", extras = ["anthropic", "openai", "pgvector", "postgres"], specifier = ">=0.7.9" },
 ]
 
@@ -4251,12 +4249,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/5c/74e4c137530dd8504e97e3a41729b1103a4ac29036cbfd3250b11fd29451/tiktoken-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cd69372e8c9dd761f0ab873112aba55a0e3e506332dd9f7522ca466e817b1b7a", size = 1258465, upload-time = "2025-02-14T06:02:45.046Z" },
     { url = "https://files.pythonhosted.org/packages/de/a8/8f499c179ec900783ffe133e9aab10044481679bb9aad78436d239eee716/tiktoken-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5ea0edb6f83dc56d794723286215918c1cde03712cbbafa0348b33448faf5b95", size = 894669, upload-time = "2025-02-14T06:02:47.341Z" },
 ]
-
-[[package]]
-name = "timeout-decorator"
-version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/80/f8/0802dd14c58b5d3d72bb9caa4315535f58787a1dc50b81bbbcaaa15451be/timeout-decorator-0.5.0.tar.gz", hash = "sha256:6a2f2f58db1c5b24a2cc79de6345760377ad8bdc13813f5265f6c3e63d16b3d7", size = 4754, upload-time = "2020-11-15T00:53:06.506Z" }
 
 [[package]]
 name = "tokenizers"


### PR DESCRIPTION
#6 introduced a bug where when we hit the timeout, then we'd see this exception get raised:

```
Traceback (most recent call last):
  ...
  File "/Users/mpeveler/code/timescale/text-to-sql-eval/suite/main.py", line 310, in run
    with psycopg.connect(
         ^^^^^^^^^^^^^^^^
  File "/Users/mpeveler/code/timescale/text-to-sql-eval/.venv/lib/python3.12/site-packages/psycopg/connection.py", line 151, in __exit__
    self.commit()
  File "/Users/mpeveler/code/timescale/text-to-sql-eval/.venv/lib/python3.12/site-packages/psycopg/connection.py", line 256, in commit
    self.wait(self._commit_gen())
  File "/Users/mpeveler/code/timescale/text-to-sql-eval/.venv/lib/python3.12/site-packages/psycopg/connection.py", line 394, in wait
    return waiting.wait(gen, self.pgconn.socket, interval=interval)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "psycopg_binary/_psycopg/waiting.pyx", line 198, in psycopg_binary._psycopg.wait_c
  File "/Users/mpeveler/code/timescale/text-to-sql-eval/.venv/lib/python3.12/site-packages/psycopg/_connection_base.py", line 577, in _commit_gen
    yield from self._exec_command(b"COMMIT")
  File "/Users/mpeveler/code/timescale/text-to-sql-eval/.venv/lib/python3.12/site-packages/psycopg/_connection_base.py", line 465, in _exec_command
    self.pgconn.send_query(command)
  File "psycopg_binary/pq/pgconn.pyx", line 239, in psycopg_binary.pq.PGconn.send_query
psycopg.OperationalError: sending query failed: another command is already in progress
```

while it's probably possible to get `timeout-decorator` to work with `psycopg`, easier to just use `statement_timeout` instead on the connection and let postgres handle doing the timeout as that's pretty foolproof and the recommended way of doing it anyway.